### PR TITLE
Fix typo in mutation testing build name

### DIFF
--- a/.github/workflows/mt.yml
+++ b/.github/workflows/mt.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: Mutatation testing with PHP ${{ matrix.php-version }}
+    name: Mutation testing with PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
### What and why? 🤔

I noticed there's a typo in the mutation testing build name (notice the text "Github Actions / **Mutatation** testing ...", so I wanted to fix it:

![image](https://github.com/leoasis/stream-builder/assets/328001/e31a9794-c69e-48ae-a6fa-a6ffc3f483c3)

### Testing Steps ✍️

Fixing a typo in a title, so no testing steps!

### You're it! 👑

Tag a random reviewer by adding `@Automattic/stream-builders` to the reviewers section, but mention them here for visibility as well.
